### PR TITLE
Dev

### DIFF
--- a/DLaB.Xrm.2015/DLaB.Xrm.2015.nuspec
+++ b/DLaB.Xrm.2015/DLaB.Xrm.2015.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>DLaB.Xrm.2015</id>
-	  <version>1.1.6-alpha01</version>
+	  <version>1.1.6.4</version>
     <authors>Daryl LaBar</authors>
     <owners>Daryl LaBar</owners>
     <licenseUrl>https://github.com/daryllabar/XrmUnitTest/blob/master/LICENSE</licenseUrl>

--- a/DLaB.Xrm.2015/DLaB.Xrm.2015.nuspec
+++ b/DLaB.Xrm.2015/DLaB.Xrm.2015.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>DLaB.Xrm.2015</id>
-	  <version>1.1.5.3</version>
+	  <version>1.1.6-alpha01</version>
     <authors>Daryl LaBar</authors>
     <owners>Daryl LaBar</owners>
     <licenseUrl>https://github.com/daryllabar/XrmUnitTest/blob/master/LICENSE</licenseUrl>

--- a/DLaB.Xrm.2015/Properties/AssemblyInfo.cs
+++ b/DLaB.Xrm.2015/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.5.3")]
-[assembly: AssemblyFileVersion("1.1.5.3")]
+[assembly: AssemblyVersion("1.1.6.1")]
+[assembly: AssemblyFileVersion("1.1.6.1")]

--- a/DLaB.Xrm.2015/Properties/AssemblyInfo.cs
+++ b/DLaB.Xrm.2015/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.6.1")]
-[assembly: AssemblyFileVersion("1.1.6.1")]
+[assembly: AssemblyVersion("1.1.6.4")]
+[assembly: AssemblyFileVersion("1.1.6.4")]

--- a/DLaB.Xrm.2016.Tests/app.config
+++ b/DLaB.Xrm.2016.Tests/app.config
@@ -54,7 +54,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="DLaB.Xrm.2016" publicKeyToken="4da76fa437c5906e" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.1.6.1" newVersion="1.1.6.1" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.6.4" newVersion="1.1.6.4" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/DLaB.Xrm.2016.Tests/app.config
+++ b/DLaB.Xrm.2016.Tests/app.config
@@ -54,7 +54,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="DLaB.Xrm.2016" publicKeyToken="4da76fa437c5906e" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.1.5.3" newVersion="1.1.5.3" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.6.1" newVersion="1.1.6.1" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/DLaB.Xrm.2016/DLaB.Xrm.2016.nuspec
+++ b/DLaB.Xrm.2016/DLaB.Xrm.2016.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>DLaB.Xrm.2016</id>
-    <version>1.1.5.3</version>
+    <version>1.1.6-alpha01</version>
     <authors>Daryl LaBar</authors>
     <owners>Daryl LaBar</owners>
     <licenseUrl>https://github.com/daryllabar/XrmUnitTest/blob/master/LICENSE</licenseUrl>

--- a/DLaB.Xrm.2016/DLaB.Xrm.2016.nuspec
+++ b/DLaB.Xrm.2016/DLaB.Xrm.2016.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>DLaB.Xrm.2016</id>
-    <version>1.1.6-alpha01</version>
+    <version>1.1.6.4</version>
     <authors>Daryl LaBar</authors>
     <owners>Daryl LaBar</owners>
     <licenseUrl>https://github.com/daryllabar/XrmUnitTest/blob/master/LICENSE</licenseUrl>

--- a/DLaB.Xrm.2016/Properties/AssemblyInfo.cs
+++ b/DLaB.Xrm.2016/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.6.1")]
-[assembly: AssemblyFileVersion("1.1.6.1")]
+[assembly: AssemblyVersion("1.1.6.4")]
+[assembly: AssemblyFileVersion("1.1.6.4")]

--- a/DLaB.Xrm.2016/Properties/AssemblyInfo.cs
+++ b/DLaB.Xrm.2016/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.5.3")]
-[assembly: AssemblyFileVersion("1.1.5.3")]
+[assembly: AssemblyVersion("1.1.6.1")]
+[assembly: AssemblyFileVersion("1.1.6.1")]

--- a/DLaB.Xrm.Base/Plugin/MessageType.cs
+++ b/DLaB.Xrm.Base/Plugin/MessageType.cs
@@ -19,8 +19,8 @@ namespace DLaB.Xrm.Plugin
         /// <param name="nameValue">The name value.</param>
         public MessageType(string nameValue) : base(nameValue, nameValue) { }
 
+        #region Default OOB CRM Message Types
 
-        // Default OOB CRM Messages
         /// <summary>
         /// Add Item Message.
         /// </summary>
@@ -389,6 +389,8 @@ namespace DLaB.Xrm.Plugin
         /// Win Message.
         /// </summary>
         public static MessageType Win = new MessageType("Win");
+
+        #endregion Default OOB CRM Message Types
 
         /// <summary>
         /// Determines whether the specified <see cref="System.Object" />, is equal to this instance.

--- a/DLaB.Xrm.Base/Plugin/RegisteredEvent.cs
+++ b/DLaB.Xrm.Base/Plugin/RegisteredEvent.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Microsoft.Xrm.Sdk;
 
 namespace DLaB.Xrm.Plugin
 {

--- a/DLaB.Xrm.Client.2015/DLaB.Xrm.Client.2015.csproj
+++ b/DLaB.Xrm.Client.2015/DLaB.Xrm.Client.2015.csproj
@@ -50,8 +50,8 @@
       <HintPath>..\packages\DLaB.Common.1.0.1.8\lib\net452\DLaB.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DLaB.Xrm.2015, Version=1.1.5.3, Culture=neutral, PublicKeyToken=4da76fa437c5906e, processorArchitecture=MSIL">
-      <HintPath>..\packages\DLaB.Xrm.2015.1.1.5.3\lib\net452\DLaB.Xrm.2015.dll</HintPath>
+    <Reference Include="DLaB.Xrm.2015, Version=1.1.6.1, Culture=neutral, PublicKeyToken=4da76fa437c5906e, processorArchitecture=MSIL">
+      <HintPath>..\packages\DLaB.Xrm.2015.1.1.6-alpha01\lib\net452\DLaB.Xrm.2015.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=7.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/DLaB.Xrm.Client.2015/DLaB.Xrm.Client.2015.csproj
+++ b/DLaB.Xrm.Client.2015/DLaB.Xrm.Client.2015.csproj
@@ -50,8 +50,8 @@
       <HintPath>..\packages\DLaB.Common.1.0.1.8\lib\net452\DLaB.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DLaB.Xrm.2015, Version=1.1.6.1, Culture=neutral, PublicKeyToken=4da76fa437c5906e, processorArchitecture=MSIL">
-      <HintPath>..\packages\DLaB.Xrm.2015.1.1.6-alpha01\lib\net452\DLaB.Xrm.2015.dll</HintPath>
+    <Reference Include="DLaB.Xrm.2015, Version=1.1.6.4, Culture=neutral, PublicKeyToken=4da76fa437c5906e, processorArchitecture=MSIL">
+      <HintPath>..\packages\DLaB.Xrm.2015.1.1.6.4\lib\net452\DLaB.Xrm.2015.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=7.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/DLaB.Xrm.Client.2015/Properties/AssemblyInfo.cs
+++ b/DLaB.Xrm.Client.2015/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.6.1")]
-[assembly: AssemblyFileVersion("1.1.6.1")]
+[assembly: AssemblyVersion("1.1.6.2")]
+[assembly: AssemblyFileVersion("1.1.6.2")]

--- a/DLaB.Xrm.Client.2015/Properties/AssemblyInfo.cs
+++ b/DLaB.Xrm.Client.2015/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.6.2")]
-[assembly: AssemblyFileVersion("1.1.6.2")]
+[assembly: AssemblyVersion("1.1.6.4")]
+[assembly: AssemblyFileVersion("1.1.6.4")]

--- a/DLaB.Xrm.Client.2015/Properties/AssemblyInfo.cs
+++ b/DLaB.Xrm.Client.2015/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.5.3")]
-[assembly: AssemblyFileVersion("1.1.5.3")]
+[assembly: AssemblyVersion("1.1.6.1")]
+[assembly: AssemblyFileVersion("1.1.6.1")]

--- a/DLaB.Xrm.Client.2015/packages.config
+++ b/DLaB.Xrm.Client.2015/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="DLaB.Common" version="1.0.1.8" targetFramework="net452" />
-  <package id="DLaB.Xrm.2015" version="1.1.6-alpha01" targetFramework="net452" />
+  <package id="DLaB.Xrm.2015" version="1.1.6.4" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.CoreAssemblies" version="7.1.1" targetFramework="net452" />

--- a/DLaB.Xrm.Client.2015/packages.config
+++ b/DLaB.Xrm.Client.2015/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="DLaB.Common" version="1.0.1.8" targetFramework="net452" />
-  <package id="DLaB.Xrm.2015" version="1.1.5.3" targetFramework="net452" />
+  <package id="DLaB.Xrm.2015" version="1.1.6-alpha01" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.CoreAssemblies" version="7.1.1" targetFramework="net452" />

--- a/DLaB.Xrm.Client.2016/DLaB.Xrm.Client.2016.csproj
+++ b/DLaB.Xrm.Client.2016/DLaB.Xrm.Client.2016.csproj
@@ -53,8 +53,8 @@
       <HintPath>..\packages\DLaB.Common.1.0.1.8\lib\net452\DLaB.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DLaB.Xrm.2016, Version=1.1.6.1, Culture=neutral, PublicKeyToken=4da76fa437c5906e, processorArchitecture=MSIL">
-      <HintPath>..\packages\DLaB.Xrm.2016.1.1.6-alpha01\lib\net452\DLaB.Xrm.2016.dll</HintPath>
+    <Reference Include="DLaB.Xrm.2016, Version=1.1.6.4, Culture=neutral, PublicKeyToken=4da76fa437c5906e, processorArchitecture=MSIL">
+      <HintPath>..\packages\DLaB.Xrm.2016.1.1.6.4\lib\net452\DLaB.Xrm.2016.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/DLaB.Xrm.Client.2016/DLaB.Xrm.Client.2016.csproj
+++ b/DLaB.Xrm.Client.2016/DLaB.Xrm.Client.2016.csproj
@@ -53,8 +53,8 @@
       <HintPath>..\packages\DLaB.Common.1.0.1.8\lib\net452\DLaB.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DLaB.Xrm.2016, Version=1.1.5.3, Culture=neutral, PublicKeyToken=4da76fa437c5906e, processorArchitecture=MSIL">
-      <HintPath>..\packages\DLaB.Xrm.2016.1.1.5.3\lib\net452\DLaB.Xrm.2016.dll</HintPath>
+    <Reference Include="DLaB.Xrm.2016, Version=1.1.6.1, Culture=neutral, PublicKeyToken=4da76fa437c5906e, processorArchitecture=MSIL">
+      <HintPath>..\packages\DLaB.Xrm.2016.1.1.6-alpha01\lib\net452\DLaB.Xrm.2016.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/DLaB.Xrm.Client.2016/Properties/AssemblyInfo.cs
+++ b/DLaB.Xrm.Client.2016/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.6.1")]
-[assembly: AssemblyFileVersion("1.1.6.1")]
+[assembly: AssemblyVersion("1.1.6.2")]
+[assembly: AssemblyFileVersion("1.1.6.2")]

--- a/DLaB.Xrm.Client.2016/Properties/AssemblyInfo.cs
+++ b/DLaB.Xrm.Client.2016/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.6.2")]
-[assembly: AssemblyFileVersion("1.1.6.2")]
+[assembly: AssemblyVersion("1.1.6.4")]
+[assembly: AssemblyFileVersion("1.1.6.4")]

--- a/DLaB.Xrm.Client.2016/Properties/AssemblyInfo.cs
+++ b/DLaB.Xrm.Client.2016/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.5.3")]
-[assembly: AssemblyFileVersion("1.1.5.3")]
+[assembly: AssemblyVersion("1.1.6.1")]
+[assembly: AssemblyFileVersion("1.1.6.1")]

--- a/DLaB.Xrm.Client.2016/packages.config
+++ b/DLaB.Xrm.Client.2016/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="DLaB.Common" version="1.0.1.8" targetFramework="net452" />
-  <package id="DLaB.Xrm.2016" version="1.1.6-alpha01" targetFramework="net452" />
+  <package id="DLaB.Xrm.2016" version="1.1.6.4" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.CoreAssemblies" version="8.0.1" targetFramework="net452" />

--- a/DLaB.Xrm.Client.2016/packages.config
+++ b/DLaB.Xrm.Client.2016/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="DLaB.Common" version="1.0.1.8" targetFramework="net452" />
-  <package id="DLaB.Xrm.2016" version="1.1.5.3" targetFramework="net452" />
+  <package id="DLaB.Xrm.2016" version="1.1.6-alpha01" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.CoreAssemblies" version="8.0.1" targetFramework="net452" />

--- a/DLaB.Xrm.LocalCrm.2015/DLaB.Xrm.LocalCrm.2015.csproj
+++ b/DLaB.Xrm.LocalCrm.2015/DLaB.Xrm.LocalCrm.2015.csproj
@@ -47,8 +47,8 @@
       <HintPath>..\packages\DLaB.Common.1.0.1.8\lib\net452\DLaB.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DLaB.Xrm.2015, Version=1.1.5.3, Culture=neutral, PublicKeyToken=4da76fa437c5906e, processorArchitecture=MSIL">
-      <HintPath>..\packages\DLaB.Xrm.2015.1.1.5.3\lib\net452\DLaB.Xrm.2015.dll</HintPath>
+    <Reference Include="DLaB.Xrm.2015, Version=1.1.6.1, Culture=neutral, PublicKeyToken=4da76fa437c5906e, processorArchitecture=MSIL">
+      <HintPath>..\packages\DLaB.Xrm.2015.1.1.6-alpha01\lib\net452\DLaB.Xrm.2015.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=7.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/DLaB.Xrm.LocalCrm.2015/DLaB.Xrm.LocalCrm.2015.csproj
+++ b/DLaB.Xrm.LocalCrm.2015/DLaB.Xrm.LocalCrm.2015.csproj
@@ -47,8 +47,8 @@
       <HintPath>..\packages\DLaB.Common.1.0.1.8\lib\net452\DLaB.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DLaB.Xrm.2015, Version=1.1.6.1, Culture=neutral, PublicKeyToken=4da76fa437c5906e, processorArchitecture=MSIL">
-      <HintPath>..\packages\DLaB.Xrm.2015.1.1.6-alpha01\lib\net452\DLaB.Xrm.2015.dll</HintPath>
+    <Reference Include="DLaB.Xrm.2015, Version=1.1.6.4, Culture=neutral, PublicKeyToken=4da76fa437c5906e, processorArchitecture=MSIL">
+      <HintPath>..\packages\DLaB.Xrm.2015.1.1.6.4\lib\net452\DLaB.Xrm.2015.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=7.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/DLaB.Xrm.LocalCrm.2015/Properties/AssemblyInfo.cs
+++ b/DLaB.Xrm.LocalCrm.2015/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.6.1")]
-[assembly: AssemblyFileVersion("1.1.6.1")]
+[assembly: AssemblyVersion("1.1.6.2")]
+[assembly: AssemblyFileVersion("1.1.6.2")]

--- a/DLaB.Xrm.LocalCrm.2015/Properties/AssemblyInfo.cs
+++ b/DLaB.Xrm.LocalCrm.2015/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.6.2")]
-[assembly: AssemblyFileVersion("1.1.6.2")]
+[assembly: AssemblyVersion("1.1.6.4")]
+[assembly: AssemblyFileVersion("1.1.6.4")]

--- a/DLaB.Xrm.LocalCrm.2015/Properties/AssemblyInfo.cs
+++ b/DLaB.Xrm.LocalCrm.2015/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.5.3")]
-[assembly: AssemblyFileVersion("1.1.5.3")]
+[assembly: AssemblyVersion("1.1.6.1")]
+[assembly: AssemblyFileVersion("1.1.6.1")]

--- a/DLaB.Xrm.LocalCrm.2015/packages.config
+++ b/DLaB.Xrm.LocalCrm.2015/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="DLaB.Common" version="1.0.1.8" targetFramework="net452" />
-  <package id="DLaB.Xrm.2015" version="1.1.6-alpha01" targetFramework="net452" />
+  <package id="DLaB.Xrm.2015" version="1.1.6.4" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.CoreAssemblies" version="7.1.1" targetFramework="net452" />
   <package id="Microsoft.IdentityModel" version="6.1.7600.16394" targetFramework="net452" />
 </packages>

--- a/DLaB.Xrm.LocalCrm.2015/packages.config
+++ b/DLaB.Xrm.LocalCrm.2015/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="DLaB.Common" version="1.0.1.8" targetFramework="net452" />
-  <package id="DLaB.Xrm.2015" version="1.1.5.3" targetFramework="net452" />
+  <package id="DLaB.Xrm.2015" version="1.1.6-alpha01" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.CoreAssemblies" version="7.1.1" targetFramework="net452" />
   <package id="Microsoft.IdentityModel" version="6.1.7600.16394" targetFramework="net452" />
 </packages>

--- a/DLaB.Xrm.LocalCrm.2016.Tests/app.config
+++ b/DLaB.Xrm.LocalCrm.2016.Tests/app.config
@@ -32,7 +32,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="DLaB.Xrm.2016" publicKeyToken="4da76fa437c5906e" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.1.6.1" newVersion="1.1.6.1" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.6.4" newVersion="1.1.6.4" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/DLaB.Xrm.LocalCrm.2016.Tests/app.config
+++ b/DLaB.Xrm.LocalCrm.2016.Tests/app.config
@@ -32,7 +32,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="DLaB.Xrm.2016" publicKeyToken="4da76fa437c5906e" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.1.5.3" newVersion="1.1.5.3" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.6.1" newVersion="1.1.6.1" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/DLaB.Xrm.LocalCrm.2016/DLaB.Xrm.LocalCrm.2016.csproj
+++ b/DLaB.Xrm.LocalCrm.2016/DLaB.Xrm.LocalCrm.2016.csproj
@@ -45,8 +45,8 @@
       <HintPath>..\packages\DLaB.Common.1.0.1.8\lib\net452\DLaB.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DLaB.Xrm.2016, Version=1.1.5.3, Culture=neutral, PublicKeyToken=4da76fa437c5906e, processorArchitecture=MSIL">
-      <HintPath>..\packages\DLaB.Xrm.2016.1.1.5.3\lib\net452\DLaB.Xrm.2016.dll</HintPath>
+    <Reference Include="DLaB.Xrm.2016, Version=1.1.6.1, Culture=neutral, PublicKeyToken=4da76fa437c5906e, processorArchitecture=MSIL">
+      <HintPath>..\packages\DLaB.Xrm.2016.1.1.6-alpha01\lib\net452\DLaB.Xrm.2016.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/DLaB.Xrm.LocalCrm.2016/DLaB.Xrm.LocalCrm.2016.csproj
+++ b/DLaB.Xrm.LocalCrm.2016/DLaB.Xrm.LocalCrm.2016.csproj
@@ -45,8 +45,8 @@
       <HintPath>..\packages\DLaB.Common.1.0.1.8\lib\net452\DLaB.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DLaB.Xrm.2016, Version=1.1.6.1, Culture=neutral, PublicKeyToken=4da76fa437c5906e, processorArchitecture=MSIL">
-      <HintPath>..\packages\DLaB.Xrm.2016.1.1.6-alpha01\lib\net452\DLaB.Xrm.2016.dll</HintPath>
+    <Reference Include="DLaB.Xrm.2016, Version=1.1.6.4, Culture=neutral, PublicKeyToken=4da76fa437c5906e, processorArchitecture=MSIL">
+      <HintPath>..\packages\DLaB.Xrm.2016.1.1.6.4\lib\net452\DLaB.Xrm.2016.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/DLaB.Xrm.LocalCrm.2016/Properties/AssemblyInfo.cs
+++ b/DLaB.Xrm.LocalCrm.2016/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.6.1")]
-[assembly: AssemblyFileVersion("1.1.6.1")]
+[assembly: AssemblyVersion("1.1.6.2")]
+[assembly: AssemblyFileVersion("1.1.6.2")]

--- a/DLaB.Xrm.LocalCrm.2016/Properties/AssemblyInfo.cs
+++ b/DLaB.Xrm.LocalCrm.2016/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.6.2")]
-[assembly: AssemblyFileVersion("1.1.6.2")]
+[assembly: AssemblyVersion("1.1.6.4")]
+[assembly: AssemblyFileVersion("1.1.6.4")]

--- a/DLaB.Xrm.LocalCrm.2016/Properties/AssemblyInfo.cs
+++ b/DLaB.Xrm.LocalCrm.2016/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.5.3")]
-[assembly: AssemblyFileVersion("1.1.5.3")]
+[assembly: AssemblyVersion("1.1.6.1")]
+[assembly: AssemblyFileVersion("1.1.6.1")]

--- a/DLaB.Xrm.LocalCrm.2016/packages.config
+++ b/DLaB.Xrm.LocalCrm.2016/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="DLaB.Common" version="1.0.1.8" targetFramework="net452" />
-  <package id="DLaB.Xrm.2016" version="1.1.6-alpha01" targetFramework="net452" />
+  <package id="DLaB.Xrm.2016" version="1.1.6.4" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.CoreAssemblies" version="8.0.1" targetFramework="net452" />
   <package id="Microsoft.IdentityModel" version="6.1.7600.16394" targetFramework="net452" />
 </packages>

--- a/DLaB.Xrm.LocalCrm.2016/packages.config
+++ b/DLaB.Xrm.LocalCrm.2016/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="DLaB.Common" version="1.0.1.8" targetFramework="net452" />
-  <package id="DLaB.Xrm.2016" version="1.1.5.3" targetFramework="net452" />
+  <package id="DLaB.Xrm.2016" version="1.1.6-alpha01" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.CoreAssemblies" version="8.0.1" targetFramework="net452" />
   <package id="Microsoft.IdentityModel" version="6.1.7600.16394" targetFramework="net452" />
 </packages>

--- a/DLaB.Xrm.Test.2015/DLaB.Xrm.Test.2015.csproj
+++ b/DLaB.Xrm.Test.2015/DLaB.Xrm.Test.2015.csproj
@@ -48,8 +48,8 @@
       <HintPath>..\packages\DLaB.Common.1.0.1.8\lib\net452\DLaB.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DLaB.Xrm.2015, Version=1.1.5.3, Culture=neutral, PublicKeyToken=4da76fa437c5906e, processorArchitecture=MSIL">
-      <HintPath>..\packages\DLaB.Xrm.2015.1.1.5.3\lib\net452\DLaB.Xrm.2015.dll</HintPath>
+    <Reference Include="DLaB.Xrm.2015, Version=1.1.6.1, Culture=neutral, PublicKeyToken=4da76fa437c5906e, processorArchitecture=MSIL">
+      <HintPath>..\packages\DLaB.Xrm.2015.1.1.6-alpha01\lib\net452\DLaB.Xrm.2015.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=7.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/DLaB.Xrm.Test.2015/DLaB.Xrm.Test.2015.csproj
+++ b/DLaB.Xrm.Test.2015/DLaB.Xrm.Test.2015.csproj
@@ -48,8 +48,8 @@
       <HintPath>..\packages\DLaB.Common.1.0.1.8\lib\net452\DLaB.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DLaB.Xrm.2015, Version=1.1.6.1, Culture=neutral, PublicKeyToken=4da76fa437c5906e, processorArchitecture=MSIL">
-      <HintPath>..\packages\DLaB.Xrm.2015.1.1.6-alpha01\lib\net452\DLaB.Xrm.2015.dll</HintPath>
+    <Reference Include="DLaB.Xrm.2015, Version=1.1.6.4, Culture=neutral, PublicKeyToken=4da76fa437c5906e, processorArchitecture=MSIL">
+      <HintPath>..\packages\DLaB.Xrm.2015.1.1.6.4\lib\net452\DLaB.Xrm.2015.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=7.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/DLaB.Xrm.Test.2015/Properties/AssemblyInfo.cs
+++ b/DLaB.Xrm.Test.2015/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.6.1")]
-[assembly: AssemblyFileVersion("1.1.6.1")]
+[assembly: AssemblyVersion("1.1.6.2")]
+[assembly: AssemblyFileVersion("1.1.6.2")]

--- a/DLaB.Xrm.Test.2015/Properties/AssemblyInfo.cs
+++ b/DLaB.Xrm.Test.2015/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.6.2")]
-[assembly: AssemblyFileVersion("1.1.6.2")]
+[assembly: AssemblyVersion("1.1.6.4")]
+[assembly: AssemblyFileVersion("1.1.6.4")]

--- a/DLaB.Xrm.Test.2015/Properties/AssemblyInfo.cs
+++ b/DLaB.Xrm.Test.2015/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.5.3")]
-[assembly: AssemblyFileVersion("1.1.5.3")]
+[assembly: AssemblyVersion("1.1.6.1")]
+[assembly: AssemblyFileVersion("1.1.6.1")]

--- a/DLaB.Xrm.Test.2015/XrmUnitTest.2015.nuspec
+++ b/DLaB.Xrm.Test.2015/XrmUnitTest.2015.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>XrmUnitTest.2015</id>
-    <version>1.1.6-alpha02</version>
+    <version>1.1.6.4</version>
     <authors>Daryl LaBar</authors>
     <owners>Daryl LaBar</owners>
     <licenseUrl>https://github.com/daryllabar/XrmUnitTest/blob/master/LICENSE</licenseUrl>
@@ -15,7 +15,7 @@
     <tags>Dynamics CRM 2015 Plugin XRM UnitTest</tags>
 	<dependencies>
     <group targetFramework=".NETFramework4.5">
-      <dependency id="DLaB.Xrm.2015" version="1.1.5.3" />
+      <dependency id="DLaB.Xrm.2015" version="1.1.6.4" />
       <dependency id="Microsoft.CrmSdk.Deployment" version="7.1.1" />
       <dependency id="Microsoft.CrmSdk.Workflow" version="7.1.1" />
       <dependency id="Microsoft.CrmSdk.Extensions" version="7.1.0.1" />

--- a/DLaB.Xrm.Test.2015/XrmUnitTest.2015.nuspec
+++ b/DLaB.Xrm.Test.2015/XrmUnitTest.2015.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>XrmUnitTest.2015</id>
-    <version>1.1.6-alpha01</version>
+    <version>1.1.6-alpha02</version>
     <authors>Daryl LaBar</authors>
     <owners>Daryl LaBar</owners>
     <licenseUrl>https://github.com/daryllabar/XrmUnitTest/blob/master/LICENSE</licenseUrl>

--- a/DLaB.Xrm.Test.2015/XrmUnitTest.2015.nuspec
+++ b/DLaB.Xrm.Test.2015/XrmUnitTest.2015.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>XrmUnitTest.2015</id>
-    <version>1.1.5.3</version>
+    <version>1.1.6-alpha01</version>
     <authors>Daryl LaBar</authors>
     <owners>Daryl LaBar</owners>
     <licenseUrl>https://github.com/daryllabar/XrmUnitTest/blob/master/LICENSE</licenseUrl>

--- a/DLaB.Xrm.Test.2015/packages.config
+++ b/DLaB.Xrm.Test.2015/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="DLaB.Common" version="1.0.1.8" targetFramework="net452" />
-  <package id="DLaB.Xrm.2015" version="1.1.6-alpha01" targetFramework="net452" />
+  <package id="DLaB.Xrm.2015" version="1.1.6.4" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.CoreAssemblies" version="7.1.1" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.Deployment" version="7.1.1" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.Extensions" version="7.1.0.1" targetFramework="net452" />

--- a/DLaB.Xrm.Test.2015/packages.config
+++ b/DLaB.Xrm.Test.2015/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="DLaB.Common" version="1.0.1.8" targetFramework="net452" />
-  <package id="DLaB.Xrm.2015" version="1.1.5.3" targetFramework="net452" />
+  <package id="DLaB.Xrm.2015" version="1.1.6-alpha01" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.CoreAssemblies" version="7.1.1" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.Deployment" version="7.1.1" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.Extensions" version="7.1.0.1" targetFramework="net452" />

--- a/DLaB.Xrm.Test.2016.Tests/app.config
+++ b/DLaB.Xrm.Test.2016.Tests/app.config
@@ -28,7 +28,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="DLaB.Xrm.2016" publicKeyToken="4da76fa437c5906e" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.1.6.1" newVersion="1.1.6.1" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.6.4" newVersion="1.1.6.4" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/DLaB.Xrm.Test.2016.Tests/app.config
+++ b/DLaB.Xrm.Test.2016.Tests/app.config
@@ -28,7 +28,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="DLaB.Xrm.2016" publicKeyToken="4da76fa437c5906e" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.1.5.3" newVersion="1.1.5.3" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.6.1" newVersion="1.1.6.1" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/DLaB.Xrm.Test.2016/DLaB.Xrm.Test.2016.csproj
+++ b/DLaB.Xrm.Test.2016/DLaB.Xrm.Test.2016.csproj
@@ -48,8 +48,8 @@
       <HintPath>..\packages\DLaB.Common.1.0.1.8\lib\net452\DLaB.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DLaB.Xrm.2016, Version=1.1.5.3, Culture=neutral, PublicKeyToken=4da76fa437c5906e, processorArchitecture=MSIL">
-      <HintPath>..\packages\DLaB.Xrm.2016.1.1.5.3\lib\net452\DLaB.Xrm.2016.dll</HintPath>
+    <Reference Include="DLaB.Xrm.2016, Version=1.1.6.1, Culture=neutral, PublicKeyToken=4da76fa437c5906e, processorArchitecture=MSIL">
+      <HintPath>..\packages\DLaB.Xrm.2016.1.1.6-alpha01\lib\net452\DLaB.Xrm.2016.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/DLaB.Xrm.Test.2016/DLaB.Xrm.Test.2016.csproj
+++ b/DLaB.Xrm.Test.2016/DLaB.Xrm.Test.2016.csproj
@@ -48,8 +48,8 @@
       <HintPath>..\packages\DLaB.Common.1.0.1.8\lib\net452\DLaB.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DLaB.Xrm.2016, Version=1.1.6.1, Culture=neutral, PublicKeyToken=4da76fa437c5906e, processorArchitecture=MSIL">
-      <HintPath>..\packages\DLaB.Xrm.2016.1.1.6-alpha01\lib\net452\DLaB.Xrm.2016.dll</HintPath>
+    <Reference Include="DLaB.Xrm.2016, Version=1.1.6.4, Culture=neutral, PublicKeyToken=4da76fa437c5906e, processorArchitecture=MSIL">
+      <HintPath>..\packages\DLaB.Xrm.2016.1.1.6.4\lib\net452\DLaB.Xrm.2016.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/DLaB.Xrm.Test.2016/Properties/AssemblyInfo.cs
+++ b/DLaB.Xrm.Test.2016/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.6.1")]
-[assembly: AssemblyFileVersion("1.1.6.1")]
+[assembly: AssemblyVersion("1.1.6.2")]
+[assembly: AssemblyFileVersion("1.1.6.2")]

--- a/DLaB.Xrm.Test.2016/Properties/AssemblyInfo.cs
+++ b/DLaB.Xrm.Test.2016/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.6.2")]
-[assembly: AssemblyFileVersion("1.1.6.2")]
+[assembly: AssemblyVersion("1.1.6.4")]
+[assembly: AssemblyFileVersion("1.1.6.4")]

--- a/DLaB.Xrm.Test.2016/Properties/AssemblyInfo.cs
+++ b/DLaB.Xrm.Test.2016/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.1.5.3")]
-[assembly: AssemblyFileVersion("1.1.5.3")]
+[assembly: AssemblyVersion("1.1.6.1")]
+[assembly: AssemblyFileVersion("1.1.6.1")]

--- a/DLaB.Xrm.Test.2016/XrmUnitTest.2016.nuspec
+++ b/DLaB.Xrm.Test.2016/XrmUnitTest.2016.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>XrmUnitTest.2016</id>
-    <version>1.1.6-alpha01</version>
+    <version>1.1.6-alpha02</version>
     <authors>Daryl LaBar</authors>
     <owners>Daryl LaBar</owners>
     <licenseUrl>https://github.com/daryllabar/XrmUnitTest/blob/master/LICENSE</licenseUrl>

--- a/DLaB.Xrm.Test.2016/XrmUnitTest.2016.nuspec
+++ b/DLaB.Xrm.Test.2016/XrmUnitTest.2016.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>XrmUnitTest.2016</id>
-    <version>1.1.6-alpha02</version>
+    <version>1.1.6.4</version>
     <authors>Daryl LaBar</authors>
     <owners>Daryl LaBar</owners>
     <licenseUrl>https://github.com/daryllabar/XrmUnitTest/blob/master/LICENSE</licenseUrl>
@@ -15,7 +15,7 @@
     <tags>Dynamics CRM 2016 Plugin XRM UnitTest</tags>
 	<dependencies>
     <group targetFramework=".NETFramework4.5">
-      <dependency id="DLaB.Xrm.2016" version="1.1.5.3" />
+      <dependency id="DLaB.Xrm.2016" version="1.1.6.4" />
       <dependency id="Microsoft.CrmSdk.Deployment" version="8.0.1" />
       <dependency id="Microsoft.CrmSdk.Workflow" version="8.0.1" />
       <dependency id="Microsoft.CrmSdk.Extensions" version="7.1.0.1" />

--- a/DLaB.Xrm.Test.2016/XrmUnitTest.2016.nuspec
+++ b/DLaB.Xrm.Test.2016/XrmUnitTest.2016.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>XrmUnitTest.2016</id>
-    <version>1.1.5.3</version>
+    <version>1.1.6-alpha01</version>
     <authors>Daryl LaBar</authors>
     <owners>Daryl LaBar</owners>
     <licenseUrl>https://github.com/daryllabar/XrmUnitTest/blob/master/LICENSE</licenseUrl>

--- a/DLaB.Xrm.Test.2016/packages.config
+++ b/DLaB.Xrm.Test.2016/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="DLaB.Common" version="1.0.1.8" targetFramework="net452" />
-  <package id="DLaB.Xrm.2016" version="1.1.6-alpha01" targetFramework="net452" />
+  <package id="DLaB.Xrm.2016" version="1.1.6.4" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.CoreAssemblies" version="8.0.1" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.Deployment" version="8.0.1" targetFramework="net452" />

--- a/DLaB.Xrm.Test.2016/packages.config
+++ b/DLaB.Xrm.Test.2016/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="DLaB.Common" version="1.0.1.8" targetFramework="net452" />
-  <package id="DLaB.Xrm.2016" version="1.1.5.3" targetFramework="net452" />
+  <package id="DLaB.Xrm.2016" version="1.1.6-alpha01" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.CoreAssemblies" version="8.0.1" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.Deployment" version="8.0.1" targetFramework="net452" />

--- a/DLaB.Xrm.Test.Base/EntityDependency.cs
+++ b/DLaB.Xrm.Test.Base/EntityDependency.cs
@@ -121,7 +121,7 @@ namespace DLaB.Xrm.Test
             }
 
             var lastDependOn = Types.LastOrDefault(t => info.DependsOn(t));
-            var firstDependOnCurrent = Types.LastOrDefault(t => t.DependsOn(info));
+            var firstDependOnCurrent = Types.FirstOrDefault(t => t.DependsOn(info));
             if (lastDependOn == null)
             {
                 if (firstDependOnCurrent == null)

--- a/DLaB.Xrm.Test.Tests.Base/Builders/CrmEnvironmentBuilderTests.cs
+++ b/DLaB.Xrm.Test.Tests.Base/Builders/CrmEnvironmentBuilderTests.cs
@@ -51,6 +51,40 @@ namespace DLaB.Xrm.Test.Tests.Builders
             AssertCrm.Exists(service, incident);
         }
 
+        /// <summary>
+        /// Incident's can't be created without a customer, so attempt to force the incident to be created first
+        /// </summary>
+        [TestMethod]
+        public void CrmEnvironmentBuilder_WithChildEntities_IncidentAndAccountButAccountAddedIncidentFirst_Should_CreateAccountFirst()
+        {
+            //
+            // Arrange
+            //
+            var service = LocalCrmDatabaseOrganizationService.CreateOrganizationService(LocalCrmDatabaseInfo.Create<CrmContext>(Guid.NewGuid().ToString()));
+            var account = new Id<Account>(Guid.NewGuid());
+            var incident = new Id<Incident>(Guid.NewGuid());
+            var lead = new Id<Lead>(Guid.NewGuid());
+
+            // The Account and Incident will be added as Account first, and Incident second. 
+            // The Lead will force an reorder and the Account incident would normally get placed after the Incident
+            var builder = new CrmEnvironmentBuilder().
+                WithEntities(new Id<PhoneCall>(Guid.NewGuid()), incident, account).
+                WithChildEntities(account, incident);
+
+            //
+            // Act
+            //
+            builder.Create(service);
+
+
+            //
+            // Assert
+            //
+
+            AssertCrm.Exists(service, account);
+            AssertCrm.Exists(service, incident);
+        }
+
         [TestMethod]
         public void CrmEnvironmentBuilder_WithEntities_GivenIdStruct_Should_CreateAll()
         {
@@ -254,6 +288,7 @@ namespace DLaB.Xrm.Test.Tests.Builders
             Assert.AreEqual(email, lead.EMailAddress1);
         }
 
+
         public class MyLeadBuilder : EntityBuilder<Lead>
         {
             public Lead Lead { get; set; }
@@ -336,6 +371,5 @@ namespace DLaB.Xrm.Test.Tests.Builders
             public static readonly Id Value1 = new Id<Contact>(Guid.NewGuid());
             public static readonly Id Value2 = new Id<Contact>(Guid.NewGuid());
         }
-
     }
 }

--- a/DLaB.Xrm.Tests.Base/DLaB.Xrm.Tests.Base.projitems
+++ b/DLaB.Xrm.Tests.Base/DLaB.Xrm.Tests.Base.projitems
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)ExtensionsIOrganizationServiceTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ExtensionsIPluginExecutionContextTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Sandbox\ExceptionHandlerTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Sandbox\Serialization\SerializableEntityTests.cs" />
   </ItemGroup>

--- a/DLaB.Xrm.Tests.Base/ExtensionsIPluginExecutionContextTests.cs
+++ b/DLaB.Xrm.Tests.Base/ExtensionsIPluginExecutionContextTests.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using DLaB.Xrm.Entities;
+using DLaB.Xrm.Plugin;
+using DLaB.Xrm.Test.Builders;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.Xrm.Sdk;
+
+namespace DLaB.Xrm.Tests
+{
+    [TestClass]
+    public class ExtensionsIPluginExecutionContextTests
+    {
+        [TestMethod]
+        public void Extensions_IPluginExecutionContext_GetTarget_ForHijackedUpdate()
+        {
+            // Currently I believe this to be a issue with CRM, where the Parent Plugin Context contain the actual Target, for the post operation.
+            // https://social.microsoft.com/Forums/en-US/19435dde-31ad-419d-826c-3f4e89ce6370/when-does-the-parent-plugin-context-contain-the-actual-target?forum=crm
+            //
+            // Arrange
+            //
+            var target = new Lead
+            {
+                Id = Guid.NewGuid(),
+                StateCode = LeadState.Open,
+                StatusCodeEnum = Lead_StatusCode.CannotContact,
+                FirstName = "Test"
+            };
+
+            var parentContext = new PluginExecutionContextBuilder().
+                WithTarget(target).Build();
+            var pluginContext = new PluginExecutionContextBuilder().
+                WithParentContext(parentContext).WithTarget(new Lead
+                {
+                    Id = target.Id,
+                    StateCode = LeadState.Open,
+                    StatusCodeEnum = Lead_StatusCode.CannotContact,
+                    ModifiedOn = DateTime.UtcNow,
+                    ModifiedBy = new EntityReference(SystemUser.EntityLogicalName, Guid.NewGuid()),
+                    ModifiedOnBehalfBy = new EntityReference(SystemUser.EntityLogicalName, Guid.NewGuid())
+                }).
+                WithRegisteredEvent(new RegisteredEvent(PipelineStage.PostOperation, MessageType.Update)).Build();
+
+            //
+            // Act
+            //
+            var pluginTarget = pluginContext.GetTarget<Lead>();
+
+            //
+            // Assert
+            //
+            Assert.AreEqual(target.FirstName, pluginTarget.FirstName);
+
+        }
+    }
+}

--- a/Example.MsTest/App.config
+++ b/Example.MsTest/App.config
@@ -28,7 +28,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="DLaB.Xrm.2016" publicKeyToken="4da76fa437c5906e" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.1.6.1" newVersion="1.1.6.1" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.6.4" newVersion="1.1.6.4" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Example.MsTest/App.config
+++ b/Example.MsTest/App.config
@@ -28,7 +28,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="DLaB.Xrm.2016" publicKeyToken="4da76fa437c5906e" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.1.5.3" newVersion="1.1.5.3" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.6.1" newVersion="1.1.6.1" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Example.MsTest/Example.MsTest.csproj
+++ b/Example.MsTest/Example.MsTest.csproj
@@ -54,20 +54,20 @@
       <HintPath>..\packages\DLaB.Common.1.0.1.8\lib\net452\DLaB.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DLaB.Xrm.2016, Version=1.1.5.3, Culture=neutral, PublicKeyToken=4da76fa437c5906e, processorArchitecture=MSIL">
-      <HintPath>..\packages\DLaB.Xrm.2016.1.1.5.3\lib\net452\DLaB.Xrm.2016.dll</HintPath>
+    <Reference Include="DLaB.Xrm.2016, Version=1.1.6.1, Culture=neutral, PublicKeyToken=4da76fa437c5906e, processorArchitecture=MSIL">
+      <HintPath>..\packages\DLaB.Xrm.2016.1.1.6-alpha01\lib\net452\DLaB.Xrm.2016.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DLaB.Xrm.Client.2016, Version=1.1.5.3, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\XrmUnitTest.2016.1.1.5.3\lib\net452\DLaB.Xrm.Client.2016.dll</HintPath>
+    <Reference Include="DLaB.Xrm.Client.2016, Version=1.1.6.2, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\XrmUnitTest.2016.1.1.6-alpha02\lib\net452\DLaB.Xrm.Client.2016.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DLaB.Xrm.LocalCrm.2016, Version=1.1.5.3, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\XrmUnitTest.2016.1.1.5.3\lib\net452\DLaB.Xrm.LocalCrm.2016.dll</HintPath>
+    <Reference Include="DLaB.Xrm.LocalCrm.2016, Version=1.1.6.2, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\XrmUnitTest.2016.1.1.6-alpha02\lib\net452\DLaB.Xrm.LocalCrm.2016.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DLaB.Xrm.Test.2016, Version=1.1.5.3, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\XrmUnitTest.2016.1.1.5.3\lib\net452\DLaB.Xrm.Test.2016.dll</HintPath>
+    <Reference Include="DLaB.Xrm.Test.2016, Version=1.1.6.2, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\XrmUnitTest.2016.1.1.6-alpha02\lib\net452\DLaB.Xrm.Test.2016.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/Example.MsTest/Example.MsTest.csproj
+++ b/Example.MsTest/Example.MsTest.csproj
@@ -54,8 +54,8 @@
       <HintPath>..\packages\DLaB.Common.1.0.1.8\lib\net452\DLaB.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DLaB.Xrm.2016, Version=1.1.6.1, Culture=neutral, PublicKeyToken=4da76fa437c5906e, processorArchitecture=MSIL">
-      <HintPath>..\packages\DLaB.Xrm.2016.1.1.6-alpha01\lib\net452\DLaB.Xrm.2016.dll</HintPath>
+    <Reference Include="DLaB.Xrm.2016, Version=1.1.6.4, Culture=neutral, PublicKeyToken=4da76fa437c5906e, processorArchitecture=MSIL">
+      <HintPath>..\packages\DLaB.Xrm.2016.1.1.6.4\lib\net452\DLaB.Xrm.2016.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="DLaB.Xrm.Client.2016, Version=1.1.6.2, Culture=neutral, processorArchitecture=MSIL">

--- a/Example.MsTest/packages.config
+++ b/Example.MsTest/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="DLaB.Common" version="1.0.1.8" targetFramework="net452" />
-  <package id="DLaB.Xrm.2016" version="1.1.5.3" targetFramework="net452" />
+  <package id="DLaB.Xrm.2016" version="1.1.6-alpha01" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.CoreAssemblies" version="8.0.1" targetFramework="net452" />
@@ -18,5 +18,5 @@
   <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net452" />
   <package id="System.IdentityModel.Tokens.Jwt" version="4.0.0" targetFramework="net452" />
   <package id="WindowsAzure.ServiceBus" version="2.5.1.0" targetFramework="net452" />
-  <package id="XrmUnitTest.2016" version="1.1.5.3" targetFramework="net452" />
+  <package id="XrmUnitTest.2016" version="1.1.6-alpha02" targetFramework="net452" />
 </packages>

--- a/Example.MsTest/packages.config
+++ b/Example.MsTest/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="DLaB.Common" version="1.0.1.8" targetFramework="net452" />
-  <package id="DLaB.Xrm.2016" version="1.1.6-alpha01" targetFramework="net452" />
+  <package id="DLaB.Xrm.2016" version="1.1.6.4" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.CoreAssemblies" version="8.0.1" targetFramework="net452" />

--- a/Example.MsTestBase/Example.MsTestBase.csproj
+++ b/Example.MsTestBase/Example.MsTestBase.csproj
@@ -49,20 +49,20 @@
       <HintPath>..\packages\DLaB.Common.1.0.1.8\lib\net452\DLaB.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DLaB.Xrm.2016, Version=1.1.5.3, Culture=neutral, PublicKeyToken=4da76fa437c5906e, processorArchitecture=MSIL">
-      <HintPath>..\packages\DLaB.Xrm.2016.1.1.5.3\lib\net452\DLaB.Xrm.2016.dll</HintPath>
+    <Reference Include="DLaB.Xrm.2016, Version=1.1.6.1, Culture=neutral, PublicKeyToken=4da76fa437c5906e, processorArchitecture=MSIL">
+      <HintPath>..\packages\DLaB.Xrm.2016.1.1.6-alpha01\lib\net452\DLaB.Xrm.2016.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DLaB.Xrm.Client.2016, Version=1.1.5.3, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\XrmUnitTest.2016.1.1.5.3\lib\net452\DLaB.Xrm.Client.2016.dll</HintPath>
+    <Reference Include="DLaB.Xrm.Client.2016, Version=1.1.6.2, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\XrmUnitTest.2016.1.1.6-alpha02\lib\net452\DLaB.Xrm.Client.2016.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DLaB.Xrm.LocalCrm.2016, Version=1.1.5.3, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\XrmUnitTest.2016.1.1.5.3\lib\net452\DLaB.Xrm.LocalCrm.2016.dll</HintPath>
+    <Reference Include="DLaB.Xrm.LocalCrm.2016, Version=1.1.6.2, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\XrmUnitTest.2016.1.1.6-alpha02\lib\net452\DLaB.Xrm.LocalCrm.2016.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DLaB.Xrm.Test.2016, Version=1.1.5.3, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\XrmUnitTest.2016.1.1.5.3\lib\net452\DLaB.Xrm.Test.2016.dll</HintPath>
+    <Reference Include="DLaB.Xrm.Test.2016, Version=1.1.6.2, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\XrmUnitTest.2016.1.1.6-alpha02\lib\net452\DLaB.Xrm.Test.2016.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/Example.MsTestBase/Example.MsTestBase.csproj
+++ b/Example.MsTestBase/Example.MsTestBase.csproj
@@ -49,8 +49,8 @@
       <HintPath>..\packages\DLaB.Common.1.0.1.8\lib\net452\DLaB.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DLaB.Xrm.2016, Version=1.1.6.1, Culture=neutral, PublicKeyToken=4da76fa437c5906e, processorArchitecture=MSIL">
-      <HintPath>..\packages\DLaB.Xrm.2016.1.1.6-alpha01\lib\net452\DLaB.Xrm.2016.dll</HintPath>
+    <Reference Include="DLaB.Xrm.2016, Version=1.1.6.4, Culture=neutral, PublicKeyToken=4da76fa437c5906e, processorArchitecture=MSIL">
+      <HintPath>..\packages\DLaB.Xrm.2016.1.1.6.4\lib\net452\DLaB.Xrm.2016.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="DLaB.Xrm.Client.2016, Version=1.1.6.2, Culture=neutral, processorArchitecture=MSIL">

--- a/Example.MsTestBase/app.config
+++ b/Example.MsTestBase/app.config
@@ -28,7 +28,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="DLaB.Xrm.2016" publicKeyToken="4da76fa437c5906e" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.1.6.1" newVersion="1.1.6.1" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.6.4" newVersion="1.1.6.4" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Example.MsTestBase/app.config
+++ b/Example.MsTestBase/app.config
@@ -28,7 +28,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="DLaB.Xrm.2016" publicKeyToken="4da76fa437c5906e" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.1.5.3" newVersion="1.1.5.3" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.6.1" newVersion="1.1.6.1" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Example.MsTestBase/packages.config
+++ b/Example.MsTestBase/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="DLaB.Common" version="1.0.1.8" targetFramework="net452" />
-  <package id="DLaB.Xrm.2016" version="1.1.5.3" targetFramework="net452" />
+  <package id="DLaB.Xrm.2016" version="1.1.6-alpha01" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.CoreAssemblies" version="8.0.1" targetFramework="net452" />
@@ -18,5 +18,5 @@
   <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net452" />
   <package id="System.IdentityModel.Tokens.Jwt" version="4.0.0" targetFramework="net452" />
   <package id="WindowsAzure.ServiceBus" version="2.5.1.0" targetFramework="net452" />
-  <package id="XrmUnitTest.2016" version="1.1.5.3" targetFramework="net452" />
+  <package id="XrmUnitTest.2016" version="1.1.6-alpha02" targetFramework="net452" />
 </packages>

--- a/Example.MsTestBase/packages.config
+++ b/Example.MsTestBase/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="DLaB.Common" version="1.0.1.8" targetFramework="net452" />
-  <package id="DLaB.Xrm.2016" version="1.1.6-alpha01" targetFramework="net452" />
+  <package id="DLaB.Xrm.2016" version="1.1.6.4" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.CoreAssemblies" version="8.0.1" targetFramework="net452" />

--- a/Example.Plugin/Example.Plugin.csproj
+++ b/Example.Plugin/Example.Plugin.csproj
@@ -43,8 +43,8 @@
       <HintPath>..\packages\DLaB.Common.1.0.1.8\lib\net452\DLaB.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DLaB.Xrm.2016, Version=1.1.6.1, Culture=neutral, PublicKeyToken=4da76fa437c5906e, processorArchitecture=MSIL">
-      <HintPath>..\packages\DLaB.Xrm.2016.1.1.6-alpha01\lib\net452\DLaB.Xrm.2016.dll</HintPath>
+    <Reference Include="DLaB.Xrm.2016, Version=1.1.6.4, Culture=neutral, PublicKeyToken=4da76fa437c5906e, processorArchitecture=MSIL">
+      <HintPath>..\packages\DLaB.Xrm.2016.1.1.6.4\lib\net452\DLaB.Xrm.2016.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/Example.Plugin/Example.Plugin.csproj
+++ b/Example.Plugin/Example.Plugin.csproj
@@ -43,8 +43,8 @@
       <HintPath>..\packages\DLaB.Common.1.0.1.8\lib\net452\DLaB.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DLaB.Xrm.2016, Version=1.1.5.3, Culture=neutral, PublicKeyToken=4da76fa437c5906e, processorArchitecture=MSIL">
-      <HintPath>..\packages\DLaB.Xrm.2016.1.1.5.3\lib\net452\DLaB.Xrm.2016.dll</HintPath>
+    <Reference Include="DLaB.Xrm.2016, Version=1.1.6.1, Culture=neutral, PublicKeyToken=4da76fa437c5906e, processorArchitecture=MSIL">
+      <HintPath>..\packages\DLaB.Xrm.2016.1.1.6-alpha01\lib\net452\DLaB.Xrm.2016.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/Example.Plugin/packages.config
+++ b/Example.Plugin/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="DLaB.Common" version="1.0.1.8" targetFramework="net452" />
-  <package id="DLaB.Xrm.2016" version="1.1.6-alpha01" targetFramework="net452" />
+  <package id="DLaB.Xrm.2016" version="1.1.6.4" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.CoreAssemblies" version="8.0.1" targetFramework="net452" />
   <package id="Microsoft.IdentityModel" version="6.1.7600.16394" targetFramework="net452" />
 </packages>

--- a/Example.Plugin/packages.config
+++ b/Example.Plugin/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="DLaB.Common" version="1.0.1.8" targetFramework="net452" />
-  <package id="DLaB.Xrm.2016" version="1.1.5.3" targetFramework="net452" />
+  <package id="DLaB.Xrm.2016" version="1.1.6-alpha01" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.CoreAssemblies" version="8.0.1" targetFramework="net452" />
   <package id="Microsoft.IdentityModel" version="6.1.7600.16394" targetFramework="net452" />
 </packages>

--- a/XrmUnitTest.Test.2016/XrmUnitTest.Test.2016.csproj
+++ b/XrmUnitTest.Test.2016/XrmUnitTest.Test.2016.csproj
@@ -51,8 +51,8 @@
       <HintPath>..\packages\DLaB.Common.1.0.1.8\lib\net452\DLaB.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DLaB.Xrm.2016, Version=1.1.6.1, Culture=neutral, PublicKeyToken=4da76fa437c5906e, processorArchitecture=MSIL">
-      <HintPath>..\packages\DLaB.Xrm.2016.1.1.6-alpha01\lib\net452\DLaB.Xrm.2016.dll</HintPath>
+    <Reference Include="DLaB.Xrm.2016, Version=1.1.6.4, Culture=neutral, PublicKeyToken=4da76fa437c5906e, processorArchitecture=MSIL">
+      <HintPath>..\packages\DLaB.Xrm.2016.1.1.6.4\lib\net452\DLaB.Xrm.2016.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="DLaB.Xrm.Client.2016, Version=1.1.6.2, Culture=neutral, processorArchitecture=MSIL">

--- a/XrmUnitTest.Test.2016/XrmUnitTest.Test.2016.csproj
+++ b/XrmUnitTest.Test.2016/XrmUnitTest.Test.2016.csproj
@@ -51,20 +51,20 @@
       <HintPath>..\packages\DLaB.Common.1.0.1.8\lib\net452\DLaB.Common.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DLaB.Xrm.2016, Version=1.1.5.3, Culture=neutral, PublicKeyToken=4da76fa437c5906e, processorArchitecture=MSIL">
-      <HintPath>..\packages\DLaB.Xrm.2016.1.1.5.3\lib\net452\DLaB.Xrm.2016.dll</HintPath>
+    <Reference Include="DLaB.Xrm.2016, Version=1.1.6.1, Culture=neutral, PublicKeyToken=4da76fa437c5906e, processorArchitecture=MSIL">
+      <HintPath>..\packages\DLaB.Xrm.2016.1.1.6-alpha01\lib\net452\DLaB.Xrm.2016.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DLaB.Xrm.Client.2016, Version=1.1.5.3, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\XrmUnitTest.2016.1.1.5.3\lib\net452\DLaB.Xrm.Client.2016.dll</HintPath>
+    <Reference Include="DLaB.Xrm.Client.2016, Version=1.1.6.2, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\XrmUnitTest.2016.1.1.6-alpha02\lib\net452\DLaB.Xrm.Client.2016.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DLaB.Xrm.LocalCrm.2016, Version=1.1.5.3, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\XrmUnitTest.2016.1.1.5.3\lib\net452\DLaB.Xrm.LocalCrm.2016.dll</HintPath>
+    <Reference Include="DLaB.Xrm.LocalCrm.2016, Version=1.1.6.2, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\XrmUnitTest.2016.1.1.6-alpha02\lib\net452\DLaB.Xrm.LocalCrm.2016.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="DLaB.Xrm.Test.2016, Version=1.1.5.3, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\XrmUnitTest.2016.1.1.5.3\lib\net452\DLaB.Xrm.Test.2016.dll</HintPath>
+    <Reference Include="DLaB.Xrm.Test.2016, Version=1.1.6.2, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\XrmUnitTest.2016.1.1.6-alpha02\lib\net452\DLaB.Xrm.Test.2016.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=8.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">

--- a/XrmUnitTest.Test.2016/app.config
+++ b/XrmUnitTest.Test.2016/app.config
@@ -62,7 +62,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="DLaB.Xrm.2016" publicKeyToken="4da76fa437c5906e" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.1.6.1" newVersion="1.1.6.1" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.6.4" newVersion="1.1.6.4" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/XrmUnitTest.Test.2016/app.config
+++ b/XrmUnitTest.Test.2016/app.config
@@ -62,7 +62,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="DLaB.Xrm.2016" publicKeyToken="4da76fa437c5906e" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.1.5.3" newVersion="1.1.5.3" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.6.1" newVersion="1.1.6.1" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/XrmUnitTest.Test.2016/packages.config
+++ b/XrmUnitTest.Test.2016/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="DLaB.Common" version="1.0.1.8" targetFramework="net452" />
-  <package id="DLaB.Xrm.2016" version="1.1.5.3" targetFramework="net452" />
+  <package id="DLaB.Xrm.2016" version="1.1.6-alpha01" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.CoreAssemblies" version="8.0.1" targetFramework="net452" />
@@ -18,5 +18,5 @@
   <package id="Newtonsoft.Json" version="8.0.2" targetFramework="net452" />
   <package id="System.IdentityModel.Tokens.Jwt" version="4.0.0" targetFramework="net452" />
   <package id="WindowsAzure.ServiceBus" version="2.5.1.0" targetFramework="net452" />
-  <package id="XrmUnitTest.2016" version="1.1.5.3" targetFramework="net452" />
+  <package id="XrmUnitTest.2016" version="1.1.6-alpha02" targetFramework="net452" />
 </packages>

--- a/XrmUnitTest.Test.2016/packages.config
+++ b/XrmUnitTest.Test.2016/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="DLaB.Common" version="1.0.1.8" targetFramework="net452" />
-  <package id="DLaB.Xrm.2016" version="1.1.6-alpha01" targetFramework="net452" />
+  <package id="DLaB.Xrm.2016" version="1.1.6.4" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net452" />
   <package id="Microsoft.CrmSdk.CoreAssemblies" version="8.0.1" targetFramework="net452" />


### PR DESCRIPTION
Build for 1.1.6.4
- First Dependent on current, was using Last or Default, rather than first or default.
- Added Check for GetTarget, to potentially look at the parent context in a really weird edge case sort of experience. https://social.microsoft.com/Forums/en-US/19435dde-31ad-419d-826c-3f4e89ce6370/when-does-the-parent-plugin-context-contain-the-actual-target?forum=crm